### PR TITLE
Allow pushing styles inside the editor scope by changing imnodes::editor to take an immutable EditorContext

### DIFF
--- a/src/scopes.rs
+++ b/src/scopes.rs
@@ -251,7 +251,7 @@ impl OuterScope {
 ///
 /// Requires the [`EditorContext`] to be set via [`EditorContext::set_as_current_editor`] beforehand.
 #[doc(alias = "BeginNodeEditor", alias = "EndNodeEditor")]
-pub fn editor<F: FnOnce(EditorScope)>(context: &mut EditorContext, f: F) -> OuterScope {
+pub fn editor<F: FnOnce(EditorScope)>(context: &EditorContext, f: F) -> OuterScope {
     // Ensure the context is set (though the user should ideally do this explicitly)
     let _ = context.set_as_current_editor();
 


### PR DESCRIPTION
Nothing in the `imnodes::editor` method requires a mutable context, and making it immutable allows for immutable borrowing of the same EditorContext inside the editor scope, eg. when wanting to push different style colors/vars for different nodes/links.
My issue could also be solved by removing all `_context: &EditorContext` arguments in `styling.rs`, but I opted to keep those since it makes sense to always have an EditorContext when pushing styles.

Example of what this change allows me to do:
```rs
let outer = imnodes::editor(editor_ctx, |mut editor| {
    let mut pass_style_tokens = vec![
        imnodes::ColorStyle::TitleBar.push_color([0.62, 0.41, 0.31, 0.70], &editor_ctx),
        imnodes::ColorStyle::TitleBarHovered.push_color([0.98, 0.52, 0.26, 0.80], &editor_ctx),
        imnodes::ColorStyle::TitleBarSelected.push_color([0.98, 0.52, 0.26], &editor_ctx),
        imnodes::ColorStyle::Pin.push_color([0.62, 0.41, 0.31, 0.70], &editor_ctx),
        imnodes::ColorStyle::PinHovered.push_color([0.98, 0.52, 0.26, 0.80], &editor_ctx),
        imnodes::ColorStyle::Link.push_color([0.62, 0.41, 0.31, 0.70], &editor_ctx),
        imnodes::ColorStyle::LinkHovered.push_color([0.98, 0.52, 0.26, 0.80], &editor_ctx),
        imnodes::ColorStyle::LinkSelected.push_color([0.98, 0.52, 0.26], &editor_ctx),
    ];
    for node in &mut self.state.pass_nodes {
        editor.add_node(...);
    }
    for link in &mut self.state.pass_links {
        editor.add_link(...);
    }

    pass_style_tokens.drain(..).for_each(|token| {
        token.pop();
    });
    let mut resource_style_tokens = vec![
        imnodes::ColorStyle::TitleBar.push_color([0.31, 0.41, 0.62, 0.70], &editor_ctx),
        imnodes::ColorStyle::TitleBarHovered.push_color([0.26, 0.52, 0.98, 0.80], &editor_ctx),
        imnodes::ColorStyle::TitleBarSelected.push_color([0.26, 0.52, 0.98], &editor_ctx),
        imnodes::ColorStyle::Pin.push_color([0.31, 0.41, 0.62, 0.70], &editor_ctx),
        imnodes::ColorStyle::PinHovered.push_color([0.26, 0.52, 0.98, 0.80], &editor_ctx),
        imnodes::ColorStyle::Link.push_color([0.31, 0.41, 0.62, 0.70], &editor_ctx),
        imnodes::ColorStyle::LinkHovered.push_color([0.26, 0.52, 0.98, 0.80], &editor_ctx),
        imnodes::ColorStyle::LinkSelected.push_color([0.26, 0.52, 0.98], &editor_ctx),
    ];
    for node in &mut self.state.resource_nodes {
        editor.add_node(...);
    }
    for link in &mut self.state.resource_links {
        editor.add_link(...);
    }
    resource_style_tokens.drain(..).for_each(|token| {
        token.pop();
    });
});
```
This would not be possible if the editor_ctx is mutably borrowed in imnodes::editor, since then there would be both mutable and immutable borrows at the same time.